### PR TITLE
chore: Add API Key as parameter for fetching stock data instead of using env variable

### DIFF
--- a/api/stocks.go
+++ b/api/stocks.go
@@ -36,7 +36,7 @@ func (s *Server) GetStockBySymbolHandler(w http.ResponseWriter, r *http.Request)
 	symbol = strings.Trim(symbol, "\"")
 	symbol = strings.Trim(symbol, "'")
 
-	data, err := fetchStockData(s.apiKey, symbol)
+	data, err := s.fetchStockData(symbol)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			http.Error(w, fmt.Sprintf("Stock data not found: %v", err), http.StatusNotFound)
@@ -66,12 +66,12 @@ func (s *Server) GetStockBySymbolHandler(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-func fetchStockData(apiKey string, symbol string) (*TimeSeriesDaily, error) {
-	if apiKey == "" {
+func (s *Server) fetchStockData(symbol string) (*TimeSeriesDaily, error) {
+	if s.apiKey == "" {
 		log.Fatalf("ALPHA_VANTAGE_API_KEY environment variable is not set")
 	}
 
-	url := fmt.Sprintf("https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=%s&apikey=%s", symbol, apiKey)
+	url := fmt.Sprintf("https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=%s&apikey=%s", symbol, s.apiKey)
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("error while calling external api: %v", err)


### PR DESCRIPTION
- Add the apiKey as an argument of the method `fetchStockData` instead of retrieving it directly from environment variable