### PR TITLE
feat: inject observer to api server

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hamba/cmd/v2/observe"
 	"github.com/hamba/logger/v2"
+	lctx "github.com/hamba/logger/v2/ctx"
 	"github.com/huy125/financial-data-web/store"
 )
 
@@ -35,7 +36,7 @@ func New(apiKey string, store Store, obsrv *observe.Observer) *Server {
 	s := &Server{
 		apiKey: apiKey,
 		store:  store,
-		log:    obsrv.Log,
+		log:    obsrv.Log.With(lctx.Str("component", "api")),
 	}
 
 	s.h = s.routes()

--- a/api/server.go
+++ b/api/server.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+	"github.com/hamba/cmd/v2/observe"
+	"github.com/hamba/logger/v2"
 	"github.com/huy125/financial-data-web/store"
 )
 
@@ -24,13 +26,16 @@ type Server struct {
 
 	apiKey string
 	store  Store
+
+	log *logger.Logger
 }
 
 // New creates a new API server.
-func New(apiKey string, store Store) *Server {
+func New(apiKey string, store Store, obsrv *observe.Observer) *Server {
 	s := &Server{
 		apiKey: apiKey,
 		store:  store,
+		log:    obsrv.Log,
 	}
 
 	s.h = s.routes()

--- a/api/users_benchmark_test.go
+++ b/api/users_benchmark_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hamba/cmd/v2/observe"
 	"github.com/huy125/financial-data-web/api"
 	"github.com/huy125/financial-data-web/store"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,8 @@ func BenchmarkGetUserHandler(b *testing.B) {
 	}
 	storeMock.On("Find", id).Return(wantUserModel, nil)
 
-	srv := api.New(testAPIKey, storeMock)
+	obsvr := observe.NewFake()
+	srv := api.New(testAPIKey, storeMock, obsvr)
 
 	httpSrv := httptest.NewServer(srv)
 	b.Cleanup(func() { httpSrv.Close() })

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hamba/cmd/v2/observe"
 	"github.com/huy125/financial-data-web/api"
 	"github.com/huy125/financial-data-web/api/dto"
 	"github.com/huy125/financial-data-web/store"
@@ -162,7 +163,8 @@ func TestServer_CreateUserHandler(t *testing.T) {
 				).Return(test.wantUserModel, test.returnErr)
 			}
 
-			srv := api.New(testAPIKey, storeMock)
+			obsvr := observe.NewFake()
+			srv := api.New(testAPIKey, storeMock, obsvr)
 
 			httpSrv := httptest.NewServer(srv)
 			t.Cleanup(func() { httpSrv.Close() })
@@ -283,7 +285,8 @@ func TestServer_UpdateUserHandler(t *testing.T) {
 				).Return(test.wantUserModel, test.returnErr)
 			}
 
-			srv := api.New(testAPIKey, storeMock)
+			obsvr := observe.NewFake()
+			srv := api.New(testAPIKey, storeMock, obsvr)
 
 			httpSrv := httptest.NewServer(srv)
 			t.Cleanup(func() { httpSrv.Close() })
@@ -369,7 +372,8 @@ func TestServer_GetUserHandler(t *testing.T) {
 			storeMock := &storeMock{}
 			storeMock.On("FindUser", id).Return(test.wantUserModel, test.returnErr)
 
-			srv := api.New(testAPIKey, storeMock)
+			obsvr := observe.NewFake()
+			srv := api.New(testAPIKey, storeMock, obsvr)
 
 			httpSrv := httptest.NewServer(srv)
 			t.Cleanup(func() { httpSrv.Close() })

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -91,7 +91,7 @@ func runServer(c *cli.Context) error {
 
 	store := store.New(db)
 	addr := net.JoinHostPort(host, port)
-	h := api.New(apiKey, store)
+	h := api.New(apiKey, store, obsrv)
 	server := server.GenericServer[context.Context]{
 		Addr:    addr,
 		Handler: h,

--- a/store/users.go
+++ b/store/users.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Model struct {
-	ID uuid.UUID
+	ID        uuid.UUID
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }


### PR DESCRIPTION
In this PR:
- Use observable logger instead of built-in logger of go in api server
- Remove unreachable log that check API key in stocks.go
- Rectify test unit